### PR TITLE
refactor auth hook usage across admin pages

### DIFF
--- a/src/app/blog/[id]/page.tsx
+++ b/src/app/blog/[id]/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 import React, { useEffect, useState, useCallback } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import { useSession } from 'next-auth/react';
 import AdminHeader from '../../../components/AdminHeader';
 import AdminFooter from '../../../components/AdminFooter';
 import Link from 'next/link';
+import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
 const LOCALES = ['en-US','pt-PT','es-ES'];
 
@@ -17,7 +17,7 @@ interface TranslationState {
 }
 
 export default function EditBlogPostPage() {
-  const { data: session, status } = useSession();
+  const { session, loading } = useAdminAuth();
   const router = useRouter();
   const params = useParams();
   const id = params?.id as string;
@@ -29,12 +29,12 @@ export default function EditBlogPostPage() {
   const [activeLocale, setActiveLocale] = useState('en-US');
   const [previewHtml, setPreviewHtml] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
-  const [loading, setLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState('');
 
   const loadBlogPost = useCallback(async () => {
     try {
-      setLoading(true);
+      setIsLoading(true);
       const res = await fetch(`/api/admin/blog/${id}`);
       
       if (res.ok) {
@@ -78,7 +78,7 @@ export default function EditBlogPostPage() {
     } catch {
       setError('Network error loading blog post');
     } finally {
-      setLoading(false);
+      setIsLoading(false);
     }
   }, [id]);
 
@@ -97,28 +97,10 @@ export default function EditBlogPostPage() {
 
   // Authentication check
   useEffect(() => {
-    if (status === 'loading') return;
-
-    if (status === 'unauthenticated') {
-      router.push('/auth/signin');
-      return;
+    if (!loading && session?.user) {
+      loadBlogPost();
     }
-
-    if (session?.user) {
-      const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-      const isAllowedDomain = allowedDomains.some(domain => 
-        session.user?.email?.endsWith(domain)
-      );
-
-      if (!isAllowedDomain) {
-        router.push('/auth/error');
-        return;
-      }
-
-  // Load blog post data if authorized
-  loadBlogPost();
-    }
-  }, [status, session, router, loadBlogPost]);
+  }, [loading, session, loadBlogPost]);
 
   function updateField(locale: string, field: keyof TranslationState, value: string) {
     setTranslations(prev => ({ 
@@ -224,7 +206,7 @@ export default function EditBlogPostPage() {
   }
 
   // Show loading state while checking authentication
-  if (status === 'loading' || loading) {
+  if (loading || isLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="loading loading-spinner loading-lg"></div>
@@ -233,11 +215,11 @@ export default function EditBlogPostPage() {
   }
 
   // Don't render content if not authorized
-  if (status === 'unauthenticated' || !session?.user) {
+  if (!session?.user) {
     return null;
   }
 
-  if (error && loading) {
+  if (error && isLoading) {
     return (
       <div className="min-h-screen flex flex-col">
         <AdminHeader />

--- a/src/app/blog/new/page.tsx
+++ b/src/app/blog/new/page.tsx
@@ -1,40 +1,19 @@
 "use client";
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { useSession } from 'next-auth/react';
 import AdminHeader from '../../../components/AdminHeader';
 import AdminFooter from '../../../components/AdminFooter';
 import Link from 'next/link';
+import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
 export default function NewBlogPostPage() {
-  const { data: session, status } = useSession();
+  const { session, loading } = useAdminAuth();
   const router = useRouter();
   const [slugBase, setSlugBase] = useState('');
   const [heroImageUrl, setHeroImageUrl] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
-  // Authentication check
-  useEffect(() => {
-    if (status === 'loading') return;
-
-    if (status === 'unauthenticated') {
-      router.push('/auth/signin');
-      return;
-    }
-
-    if (session?.user) {
-      const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-      const isAllowedDomain = allowedDomains.some(domain => 
-        session.user?.email?.endsWith(domain)
-      );
-
-      if (!isAllowedDomain) {
-        router.push('/auth/error');
-        return;
-      }
-    }
-  }, [status, session, router]);
 
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();
@@ -72,7 +51,7 @@ export default function NewBlogPostPage() {
   }
 
   // Show loading state while checking authentication
-  if (status === 'loading') {
+  if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="loading loading-spinner loading-lg"></div>
@@ -81,7 +60,7 @@ export default function NewBlogPostPage() {
   }
 
   // Don't render content if not authorized
-  if (status === 'unauthenticated' || !session?.user) {
+  if (!session?.user) {
     return null;
   }
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -2,10 +2,10 @@
 
 import React, { useEffect, useState, useCallback, Suspense } from 'react';
 import Link from 'next/link';
-import { useSession } from 'next-auth/react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import AdminHeader from '../../components/AdminHeader';
 import AdminFooter from '../../components/AdminFooter';
+import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
 interface BlogListTranslation { 
   locale: string; 
@@ -24,16 +24,16 @@ interface BlogListItem {
 }
 
 function BlogListContent() {
-  const { data: session, status } = useSession();
+  const { session, loading } = useAdminAuth();
   const router = useRouter();
   const searchParams = useSearchParams();
   const [posts, setPosts] = useState<BlogListItem[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loadingPosts, setLoadingPosts] = useState(true);
   const [deletingId, setDeletingId] = useState<string | null>(null);
 
   const fetchBlogList = useCallback(async () => {
     try {
-      setLoading(true);
+      setLoadingPosts(true);
       const qp = new URLSearchParams();
       if (searchParams.get('status')) qp.set('status', searchParams.get('status')!);
       if (searchParams.get('locale')) qp.set('locale', searchParams.get('locale')!);
@@ -55,34 +55,15 @@ function BlogListContent() {
       console.error('Error fetching blog posts');
       setPosts([]);
     } finally {
-      setLoading(false);
+      setLoadingPosts(false);
     }
   }, [searchParams]);
 
-  // Authentication check
   useEffect(() => {
-    if (status === 'loading') return;
-
-    if (status === 'unauthenticated') {
-      router.push('/auth/signin');
-      return;
-    }
-
-    if (session?.user) {
-      const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-      const isAllowedDomain = allowedDomains.some(domain => 
-        session.user?.email?.endsWith(domain)
-      );
-
-      if (!isAllowedDomain) {
-        router.push('/auth/error');
-        return;
-      }
-
-      // Fetch blog posts if authorized
+    if (!loading && session?.user) {
       fetchBlogList();
     }
-  }, [status, session, router, fetchBlogList]);
+  }, [loading, session, fetchBlogList]);
 
   const handleDeletePost = async (postId: string, slugBase: string) => {
     const confirmed = confirm(`Are you sure you want to delete the blog post "${slugBase}"? This action cannot be undone.`);
@@ -112,7 +93,7 @@ function BlogListContent() {
   };
 
   // Show loading state while checking authentication
-  if (status === 'loading') {
+  if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="loading loading-spinner loading-lg"></div>
@@ -121,7 +102,7 @@ function BlogListContent() {
   }
 
   // Don't render content if not authorized
-  if (status === 'unauthenticated' || !session?.user) {
+  if (!session?.user) {
     return null;
   }
 
@@ -197,7 +178,7 @@ function BlogListContent() {
             </div>
           </form>
 
-          {loading ? (
+          {loadingPosts ? (
             <div className="flex justify-center py-12">
               <div className="loading loading-spinner loading-lg"></div>
             </div>

--- a/src/app/managers/page.tsx
+++ b/src/app/managers/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useSession } from 'next-auth/react';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import AdminHeader from '../../components/AdminHeader';
 import AdminFooter from '../../components/AdminFooter';
+import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
 interface Manager {
   managerId: string;
@@ -24,7 +24,7 @@ interface ManagerFormData {
 }
 
 export default function ManagersPage() {
-  const { data: session, status } = useSession();
+  const { session, loading } = useAdminAuth();
   const router = useRouter();
   const [managers, setManagers] = useState<Manager[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -59,29 +59,10 @@ export default function ManagersPage() {
   };
 
   useEffect(() => {
-    if (status === 'loading') return;
-
-    if (status === 'unauthenticated') {
-      router.push('/auth/signin');
-      return;
-    }
-
-    if (session?.user) {
-      // Check if user has the required email domain
-      const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-      const isAllowedDomain = allowedDomains.some(domain => 
-        session.user?.email?.endsWith(domain)
-      );
-
-      if (!isAllowedDomain) {
-        router.push('/auth/error');
-        return;
-      }
-
-      // Fetch managers data if authorized
+    if (!loading && session?.user) {
       fetchManagers();
     }
-  }, [status, session, router]);
+  }, [loading, session]);
 
   const handleCreateNew = () => {
     setEditingManager(null);
@@ -166,7 +147,7 @@ export default function ManagersPage() {
     }
   };
 
-  if (status === 'loading' || isLoading) {
+  if (loading || isLoading) {
     return (
       <div className="min-h-screen bg-base-200">
         <AdminHeader />
@@ -178,6 +159,10 @@ export default function ManagersPage() {
         <AdminFooter />
       </div>
     );
+  }
+
+  if (!session?.user) {
+    return null;
   }
 
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import { useSession } from 'next-auth/react';
 import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
 import AdminHeader from '../components/AdminHeader';
 import AdminFooter from '../components/AdminFooter';
 import KPICard from '../components/KPICard';
+import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
 interface KPIData {
   users: number;
@@ -14,35 +13,15 @@ interface KPIData {
 }
 
 export default function AdminPortal() {
-  const { data: session, status } = useSession();
-  const router = useRouter();
+  const { session, loading } = useAdminAuth();
   const [kpis, setKpis] = useState<KPIData | null>(null);
   const [isLoadingKpis, setIsLoadingKpis] = useState(true);
 
   useEffect(() => {
-    if (status === 'loading') return; // Still loading
-
-    if (status === 'unauthenticated') {
-      router.push('/auth/signin');
-      return;
-    }
-
-    if (session?.user) {
-      // Check if user has the required email domain (already validated in auth.ts)
-      const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-      const isAllowedDomain = allowedDomains.some(domain => 
-        session.user?.email?.endsWith(domain)
-      );
-
-      if (!isAllowedDomain) {
-        router.push('/auth/error');
-        return;
-      }
-
-      // Fetch KPI data if authorized
+    if (!loading && session?.user) {
       fetchKPIs();
     }
-  }, [status, session, router]);
+  }, [loading, session]);
 
   const fetchKPIs = async () => {
     try {
@@ -62,16 +41,16 @@ export default function AdminPortal() {
   };
 
   // Show loading state while checking authentication
-  if (status === 'loading') {
+  if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="loading loading-spinner loading-lg"></div>
       </div>
     );
   }
-  
+
   // Don't render content if not authorized
-  if (status === 'unauthenticated' || !session?.user) {
+  if (!session?.user) {
     return null;
   }
 

--- a/src/app/pricing/add/page.tsx
+++ b/src/app/pricing/add/page.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { useSession } from 'next-auth/react';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import AdminHeader from '@/components/AdminHeader';
 import AdminFooter from '@/components/AdminFooter';
+import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
 export default function AddCreditPackagePage() {
-  const { data: session, status } = useSession();
+  const { session, loading } = useAdminAuth();
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
   const [formData, setFormData] = useState({
@@ -19,25 +19,10 @@ export default function AddCreditPackagePage() {
   });
 
   useEffect(() => {
-    if (status === 'loading') return;
-
-    if (status === 'unauthenticated') {
+    if (!loading && !session?.user) {
       router.push('/auth/signin');
-      return;
     }
-
-    if (session?.user) {
-      const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-      const isAllowedDomain = allowedDomains.some(domain => 
-        session.user?.email?.endsWith(domain)
-      );
-
-      if (!isAllowedDomain) {
-        router.push('/auth/error');
-        return;
-      }
-    }
-  }, [status, session, router]);
+  }, [loading, session, router]);
 
   const calculateCostPerCredit = () => {
     if (formData.credits > 0 && formData.price && parseFloat(formData.price) > 0) {
@@ -82,7 +67,7 @@ export default function AddCreditPackagePage() {
     router.push('/pricing');
   };
 
-  if (status === 'loading') {
+  if (loading) {
     return (
       <div className="min-h-screen bg-base-200">
         <AdminHeader />
@@ -94,6 +79,10 @@ export default function AddCreditPackagePage() {
         <AdminFooter />
       </div>
     );
+  }
+
+  if (!session?.user) {
+    return null;
   }
 
   return (

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useSession } from 'next-auth/react';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import AdminHeader from '@/components/AdminHeader';
 import AdminFooter from '@/components/AdminFooter';
+import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
 interface CreditPackage {
   id: string;
@@ -23,33 +23,16 @@ interface CreditPackage {
 
 
 export default function PricingPage() {
-  const { data: session, status } = useSession();
+  const { session, loading } = useAdminAuth();
   const router = useRouter();
   const [creditPackages, setCreditPackages] = useState<CreditPackage[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    if (status === 'loading') return;
-
-    if (status === 'unauthenticated') {
-      router.push('/auth/signin');
-      return;
-    }
-
-    if (session?.user) {
-      const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-      const isAllowedDomain = allowedDomains.some(domain => 
-        session.user?.email?.endsWith(domain)
-      );
-
-      if (!isAllowedDomain) {
-        router.push('/auth/error');
-        return;
-      }
-
+    if (!loading && session?.user) {
       fetchCreditPackages();
     }
-  }, [status, session, router]);
+  }, [loading, session]);
 
   const fetchCreditPackages = async () => {
     try {
@@ -84,7 +67,7 @@ export default function PricingPage() {
     }
   };
 
-  if (status === 'loading' || isLoading) {
+  if (loading || isLoading) {
     return (
       <div className="min-h-screen bg-base-200">
         <AdminHeader />
@@ -96,6 +79,10 @@ export default function PricingPage() {
         <AdminFooter />
       </div>
     );
+  }
+
+  if (!session?.user) {
+    return null;
   }
 
   return (

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useSession } from 'next-auth/react';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import AdminHeader from '@/components/AdminHeader';
 import AdminFooter from '@/components/AdminFooter';
 import { formatAdminDate } from '@/lib/date-utils';
+import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
 interface Service {
   id: string;
@@ -17,7 +17,7 @@ interface Service {
 }
 
 export default function ServicesPage() {
-  const { data: session, status } = useSession();
+  const { session, loading } = useAdminAuth();
   const router = useRouter();
   const [services, setServices] = useState<Service[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -30,27 +30,10 @@ export default function ServicesPage() {
   });
 
   useEffect(() => {
-    if (status === 'loading') return;
-
-    if (status === 'unauthenticated') {
-      router.push('/auth/signin');
-      return;
-    }
-
-    if (session?.user) {
-      const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-      const isAllowedDomain = allowedDomains.some(domain => 
-        session.user?.email?.endsWith(domain)
-      );
-
-      if (!isAllowedDomain) {
-        router.push('/auth/error');
-        return;
-      }
-
+    if (!loading && session?.user) {
       fetchServices();
     }
-  }, [status, session, router]);
+  }, [loading, session]);
 
   const fetchServices = async () => {
     try {
@@ -152,7 +135,7 @@ export default function ServicesPage() {
     }
   };
 
-  if (status === 'loading' || isLoading) {
+  if (loading || isLoading) {
     return (
       <div className="min-h-screen bg-base-200">
         <AdminHeader />
@@ -164,6 +147,10 @@ export default function ServicesPage() {
         <AdminFooter />
       </div>
     );
+  }
+
+  if (!session?.user) {
+    return null;
   }
 
   return (

--- a/src/app/stories/[storyId]/read/chapter/[chapterNumber]/page.tsx
+++ b/src/app/stories/[storyId]/read/chapter/[chapterNumber]/page.tsx
@@ -78,34 +78,13 @@ export default function ReadChapterPage() {
   }, [storyId, chapterNumber]);
 
   useEffect(() => {
-    if (status === 'loading') return;
-
-    if (status === 'unauthenticated') {
-      router.push('/auth/signin');
-      return;
+    if (!loading && session?.user && storyId && chapterNumber) {
+      fetchChapter();
     }
-
-    if (session?.user) {
-      // Check if user has the required email domain
-      const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-      const isAllowedDomain = allowedDomains.some(domain => 
-        session.user?.email?.endsWith(domain)
-      );
-
-      if (!isAllowedDomain) {
-        router.push('/auth/error');
-        return;
-      }
-
-      // Fetch chapter data
-      if (storyId && chapterNumber) {
-        fetchChapter();
-      }
-    }
-  }, [status, session, router, fetchChapter, storyId, chapterNumber]);
+  }, [loading, session, fetchChapter, storyId, chapterNumber]);
 
   // Show loading state while checking authentication
-  if (status === 'loading' || isLoading) {
+  if (loading || isLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="loading loading-spinner loading-lg"></div>
@@ -114,7 +93,7 @@ export default function ReadChapterPage() {
   }
 
   // Don't render content if not authorized
-  if (status === 'unauthenticated' || !session?.user) {
+  if (!session?.user) {
     return null;
   }
 

--- a/src/app/stories/[storyId]/read/page.tsx
+++ b/src/app/stories/[storyId]/read/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useSession } from 'next-auth/react';
 import { useEffect, useState, useCallback } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import AdminHeader from '../../../../components/AdminHeader';
 import AdminFooter from '../../../../components/AdminFooter';
 import AdminStoryReader from '../../../../components/AdminStoryReader';
+import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
 interface Chapter {
   id: string;
@@ -30,7 +30,7 @@ interface Story {
 }
 
 export default function ReadStoryPage() {
-  const { data: session, status } = useSession();
+  const { session, loading } = useAdminAuth();
   const router = useRouter();
   const params = useParams();
   const storyId = params?.storyId as string;
@@ -73,32 +73,13 @@ export default function ReadStoryPage() {
   }, [storyId]);
 
   useEffect(() => {
-    if (status === 'loading') return;
-
-    if (status === 'unauthenticated') {
-      router.push('/auth/signin');
-      return;
-    }
-
-    if (session?.user) {
-      // Check if user has the required email domain
-      const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-      const isAllowedDomain = allowedDomains.some(domain => 
-        session.user?.email?.endsWith(domain)
-      );
-
-      if (!isAllowedDomain) {
-        router.push('/auth/error');
-        return;
-      }
-
-      // Fetch story data
+    if (!loading && session?.user) {
       fetchStory();
     }
-  }, [status, session, router, fetchStory]);
+  }, [loading, session, fetchStory]);
 
   // Show loading state while checking authentication
-  if (status === 'loading' || isLoading) {
+  if (loading || isLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="loading loading-spinner loading-lg"></div>
@@ -107,7 +88,7 @@ export default function ReadStoryPage() {
   }
 
   // Don't render content if not authorized
-  if (status === 'unauthenticated' || !session?.user) {
+  if (!session?.user) {
     return null;
   }
 

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { useSession } from 'next-auth/react';
 import { useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import AdminHeader from '../../components/AdminHeader';
 import AdminFooter from '../../components/AdminFooter';
 import { formatAdminDate } from '@/lib/date-utils';
+import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
 interface User {
   authorId: string;
@@ -35,7 +35,7 @@ type SortField = 'displayName' | 'email' | 'createdAt';
 type SortOrder = 'asc' | 'desc';
 
 export default function UsersPage() {
-  const { data: session, status } = useSession();
+  const { session, loading } = useAdminAuth();
   const router = useRouter();
   const [users, setUsers] = useState<User[]>([]);
   const [pagination, setPagination] = useState<PaginationData | null>(null);
@@ -72,29 +72,10 @@ export default function UsersPage() {
   }, [searchTerm, sortField, sortOrder]);
 
   useEffect(() => {
-    if (status === 'loading') return;
-
-    if (status === 'unauthenticated') {
-      router.push('/auth/signin');
-      return;
-    }
-
-    if (session?.user) {
-      // Check if user has the required email domain
-      const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-      const isAllowedDomain = allowedDomains.some(domain => 
-        session.user?.email?.endsWith(domain)
-      );
-
-      if (!isAllowedDomain) {
-        router.push('/auth/error');
-        return;
-      }
-
-      // Fetch users data if authorized
+    if (!loading && session?.user) {
       fetchUsers(currentPage);
     }
-  }, [status, session, router, currentPage, fetchUsers]);
+  }, [loading, session, currentPage, fetchUsers]);
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
@@ -121,7 +102,7 @@ export default function UsersPage() {
   };
 
   // Show loading state while checking authentication
-  if (status === 'loading') {
+  if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="loading loading-spinner loading-lg"></div>
@@ -130,7 +111,7 @@ export default function UsersPage() {
   }
 
   // Don't render content if not authorized
-  if (status === 'unauthenticated' || !session?.user) {
+  if (!session?.user) {
     return null;
   }
 

--- a/src/lib/hooks/useAdminAuth.ts
+++ b/src/lib/hooks/useAdminAuth.ts
@@ -1,0 +1,41 @@
+'use client';
+
+import { useSession } from 'next-auth/react';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+const allowedDomains = ['@mythoria.pt', '@caravanconcierge.com'];
+
+export const useAdminAuth = () => {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (status === 'loading') {
+      return;
+    }
+
+    if (status === 'unauthenticated') {
+      router.push('/auth/signin');
+      return;
+    }
+
+    if (session?.user) {
+      const isAllowedDomain = allowedDomains.some((domain) =>
+        session.user?.email?.endsWith(domain),
+      );
+
+      if (!isAllowedDomain) {
+        router.push('/auth/error');
+        return;
+      }
+    }
+
+    setLoading(false);
+  }, [status, session, router]);
+
+  return { session, loading: loading || status === 'loading' };
+};
+
+export default useAdminAuth;


### PR DESCRIPTION
## Summary
- add `useAdminAuth` hook for session retrieval, domain validation, and redirects
- replace repeated authentication `useEffect` blocks across admin pages with hook
- expose `{session, loading}` to simplify loading and authorization checks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1fd79667c8328b706932d187b1c41