### PR TITLE
chore: centralize allowed domains

### DIFF
--- a/__tests__/auth.test.ts
+++ b/__tests__/auth.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 // Mock environment variables for testing
 process.env.GOOGLE_CLIENT_ID = 'test-client-id';
@@ -53,8 +54,7 @@ describe('Authentication Configuration', () => {
     // Simulate the signIn callback logic
     const isGoogleProvider = mockAccount.provider === 'google';
     const isEmailVerified = mockProfile.email_verified;
-    const allowedDomains = ['@mythoria.pt', '@caravanconcierge.com'];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain =>
       mockProfile.email.endsWith(domain)
     );
     
@@ -69,8 +69,6 @@ describe('Authentication Configuration', () => {
   });
 
   it('should validate email domains correctly', () => {
-    const allowedDomains = ['@mythoria.pt', '@caravanconcierge.com'];
-    
     const validEmails = [
       'user@mythoria.pt',
       'admin@mythoria.pt',
@@ -87,12 +85,12 @@ describe('Authentication Configuration', () => {
     ];
 
     validEmails.forEach(email => {
-      const isValid = allowedDomains.some(domain => email.endsWith(domain));
+      const isValid = ALLOWED_DOMAINS.some(domain => email.endsWith(domain));
       expect(isValid).toBe(true);
     });
 
     invalidEmails.forEach(email => {
-      const isValid = allowedDomains.some(domain => email.endsWith(domain));
+      const isValid = ALLOWED_DOMAINS.some(domain => email.endsWith(domain));
       expect(isValid).toBe(false);
     });
   });
@@ -113,8 +111,9 @@ describe('Authentication Configuration', () => {
     
     // All verified profiles should have valid domains
     verifiedProfiles.forEach(profile => {
-      const hasValidDomain = profile.email.endsWith('@mythoria.pt') || 
-                            profile.email.endsWith('@caravanconcierge.com');
+      const hasValidDomain = ALLOWED_DOMAINS.some(domain =>
+        profile.email.endsWith(domain)
+      );
       expect(hasValidDomain).toBe(true);
     });
   });

--- a/__tests__/signin.test.tsx
+++ b/__tests__/signin.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { signIn } from 'next-auth/react';
 import SignInPage from '@/app/auth/signin/page';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 // Mock next-auth/react
 jest.mock('next-auth/react', () => ({
@@ -20,7 +21,8 @@ describe('SignIn Page', () => {
     expect(screen.getByText('Mythoria Admin')).toBeInTheDocument();
     expect(screen.getByText('Administration Portal')).toBeInTheDocument();
     expect(screen.getByText('Sign in with Google')).toBeInTheDocument();
-    expect(screen.getByText(/Access restricted to @mythoria.pt and @caravanconcierge.com/)).toBeInTheDocument();
+    const domainText = ALLOWED_DOMAINS.join(' and ');
+    expect(screen.getByText(`Access restricted to ${domainText}`)).toBeInTheDocument();
   });
 
   it('calls signIn when Google sign-in button is clicked', async () => {
@@ -56,7 +58,8 @@ describe('SignIn Page', () => {
   it('displays domain restriction warning', () => {
     render(<SignInPage />);
     
-    const warning = screen.getByText(/Access restricted to @mythoria.pt and @caravanconcierge.com/);
+    const domainText = ALLOWED_DOMAINS.join(' and ');
+    const warning = screen.getByText(`Access restricted to ${domainText}`);
     expect(warning).toBeInTheDocument();
   });
 

--- a/src/app/api/admin/blog/[id]/publish/route.ts
+++ b/src/app/api/admin/blog/[id]/publish/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { adminBlogService } from '@/db/services';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 function ensureAdminEmail(email?: string | null) {
   if (!email) return false;
-  const allowedDomains = ['@mythoria.pt', '@caravanconcierge.com'];
-  return allowedDomains.some(d => email.endsWith(d));
+  return ALLOWED_DOMAINS.some(d => email.endsWith(d));
 }
 
 export async function POST(req: Request) {

--- a/src/app/api/admin/blog/[id]/route.ts
+++ b/src/app/api/admin/blog/[id]/route.ts
@@ -2,11 +2,11 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { adminBlogService } from '@/db/services';
 import { validateMdxSource } from '@/lib/blog/mdx-validate';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 function ensureAdminEmail(email?: string | null) {
   if (!email) return false;
-  const allowedDomains = ['@mythoria.pt', '@caravanconcierge.com'];
-  return allowedDomains.some(d => email.endsWith(d));
+  return ALLOWED_DOMAINS.some(d => email.endsWith(d));
 }
 
 export async function GET(req: Request) {

--- a/src/app/api/admin/blog/mdx/preview/route.ts
+++ b/src/app/api/admin/blog/mdx/preview/route.ts
@@ -10,11 +10,11 @@ import { unified } from 'unified';
 import remarkParse from 'remark-parse';
 import remarkRehype from 'remark-rehype';
 import rehypeStringify from 'rehype-stringify';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 function ensureAdminEmail(email?: string | null) {
   if (!email) return false;
-  const allowedDomains = ['@mythoria.pt', '@caravanconcierge.com'];
-  return allowedDomains.some(d => email.endsWith(d));
+  return ALLOWED_DOMAINS.some(d => email.endsWith(d));
 }
 
 export async function POST(req: Request) {

--- a/src/app/api/admin/blog/route.ts
+++ b/src/app/api/admin/blog/route.ts
@@ -2,11 +2,11 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { adminBlogService } from '@/db/services';
 import { validateMdxSource } from '@/lib/blog/mdx-validate';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 function ensureAdminEmail(email?: string | null) {
   if (!email) return false;
-  const allowedDomains = ['@mythoria.pt', '@caravanconcierge.com'];
-  return allowedDomains.some(d => email.endsWith(d));
+  return ALLOWED_DOMAINS.some(d => email.endsWith(d));
 }
 
 export async function GET(req: Request) {

--- a/src/app/api/admin/kpis/route.ts
+++ b/src/app/api/admin/kpis/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { adminService } from '@/db/services';
 import { TicketService } from '@/lib/ticketing/service';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 export async function GET() {
   try {
@@ -12,8 +13,7 @@ export async function GET() {
     }
 
     // Check if user has admin access (email domain is already validated in auth.ts)
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/admin/managers/[id]/route.ts
+++ b/src/app/api/admin/managers/[id]/route.ts
@@ -3,6 +3,7 @@ import { auth } from '@/auth';
 import { getBackofficeDb } from '@/db';
 import { managers } from '@/db/schema';
 import { eq } from 'drizzle-orm';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 interface RouteParams {
   params: Promise<{
@@ -23,8 +24,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
 
     // Check if user has the required email domain
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 
@@ -78,8 +78,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     }
 
     // Check if user has the required email domain
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 
@@ -194,8 +193,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     }
 
     // Check if user has the required email domain
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/admin/managers/route.ts
+++ b/src/app/api/admin/managers/route.ts
@@ -3,6 +3,7 @@ import { auth } from '@/auth';
 import { getBackofficeDb } from '@/db';
 import { managers, type NewManager } from '@/db/schema';
 import { eq } from 'drizzle-orm';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 /**
  * GET /api/admin/managers
@@ -17,8 +18,7 @@ export async function GET() {
     }
 
     // Check if user has the required email domain
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 
@@ -62,8 +62,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Check if user has the required email domain
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/admin/print-requests/route.ts
+++ b/src/app/api/admin/print-requests/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { adminService } from '@/db/services';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 export async function GET(request: Request) {
   try {
@@ -11,8 +12,7 @@ export async function GET(request: Request) {
     }
 
     // Check if user has admin access (email domain is already validated in auth.ts)
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/admin/stories/[storyId]/chapters/[chapterNumber]/route.ts
+++ b/src/app/api/admin/stories/[storyId]/chapters/[chapterNumber]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { adminService } from '@/db/services';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 export async function GET(
   request: Request, 
@@ -14,8 +15,7 @@ export async function GET(
     }
 
     // Check if user has admin access
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/admin/stories/[storyId]/chapters/route.ts
+++ b/src/app/api/admin/stories/[storyId]/chapters/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { adminService } from '@/db/services';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 // Minimal chapter shape expected from adminService.getStoryWithChapters
 type ChapterResult = {
@@ -28,8 +29,7 @@ export async function GET(
     }
 
     // Check if user has admin access
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/admin/stories/[storyId]/feature/route.ts
+++ b/src/app/api/admin/stories/[storyId]/feature/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { adminService } from '@/db/services';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 export async function PATCH(
   request: Request, 
@@ -14,8 +15,7 @@ export async function PATCH(
     }
 
     // Check if user has admin access (email domain is already validated in auth.ts)
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/admin/stories/[storyId]/restart/route.ts
+++ b/src/app/api/admin/stories/[storyId]/restart/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { adminService } from '@/db/services';
 import { publishStoryRequest } from '@/lib/pubsub';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 // POST /api/admin/stories/[storyId]/restart - Restart story generation workflow
 export async function POST(
@@ -15,8 +16,7 @@ export async function POST(
     }
 
     // Check if user has admin access
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/admin/stories/[storyId]/route.ts
+++ b/src/app/api/admin/stories/[storyId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { adminService } from '@/db/services';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 export async function GET(
   request: Request, 
@@ -14,8 +15,7 @@ export async function GET(
     }
 
     // Check if user has admin access (email domain is already validated in auth.ts)
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 
@@ -51,8 +51,7 @@ export async function PATCH(
     }
 
     // Check if user has admin access (email domain is already validated in auth.ts)
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/admin/stories/route.ts
+++ b/src/app/api/admin/stories/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { adminService } from '@/db/services';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 export async function GET(request: Request) {
   try {
@@ -11,8 +12,7 @@ export async function GET(request: Request) {
     }
 
     // Check if user has admin access (email domain is already validated in auth.ts)
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/admin/users/[id]/assign-credits/route.ts
+++ b/src/app/api/admin/users/[id]/assign-credits/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { adminService } from '@/db/services';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 export async function POST(
   request: Request, 
@@ -14,8 +15,7 @@ export async function POST(
     }
 
     // Check if user has admin access
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/admin/users/[id]/credits/route.ts
+++ b/src/app/api/admin/users/[id]/credits/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { adminService } from '@/db/services';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 export async function GET(
   request: Request, 
@@ -14,8 +15,7 @@ export async function GET(
     }
 
     // Check if user has admin access
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { adminService } from '@/db/services';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 export async function GET(
   request: Request, 
@@ -14,8 +15,7 @@ export async function GET(
     }
 
     // Check if user has admin access (email domain is already validated in auth.ts)
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/admin/users/[id]/stories/route.ts
+++ b/src/app/api/admin/users/[id]/stories/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { adminService } from '@/db/services';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 export async function GET(
   request: Request,
@@ -12,8 +13,7 @@ export async function GET(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"]; 
-    const isAllowedDomain = allowedDomains.some(domain => session.user?.email?.endsWith(domain));
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => session.user?.email?.endsWith(domain));
     if (!isAllowedDomain) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { adminService } from '@/db/services';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 export async function GET(request: Request) {
   try {
@@ -11,8 +12,7 @@ export async function GET(request: Request) {
     }
 
     // Check if user has admin access (email domain is already validated in auth.ts)
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/ai-usage/records/route.ts
+++ b/src/app/api/ai-usage/records/route.ts
@@ -3,6 +3,7 @@ import { getWorkflowsDb } from '@/db';
 import { tokenUsageTracking } from '@/db/schema/workflows/token-usage';
 import { and, gte, lte, desc, asc, eq, like, or, count } from 'drizzle-orm';
 import { auth } from '@/auth';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 // Type for valid AI action types
 type AIActionType = 'story_structure' | 'story_outline' | 'chapter_writing' | 'image_generation' | 'story_review' | 'character_generation' | 'story_enhancement' | 'audio_generation' | 'content_validation' | 'image_edit' | 'test';
@@ -61,8 +62,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Check if user has access (domain validation)
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/ai-usage/stats/route.ts
+++ b/src/app/api/ai-usage/stats/route.ts
@@ -3,6 +3,7 @@ import { getWorkflowsDb } from '@/db';
 import { tokenUsageTracking } from '@/db/schema/workflows/token-usage';
 import { and, gte, lte, sql, desc } from 'drizzle-orm';
 import { auth } from '@/auth';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 // Types for the API responses
 export interface TokenUsageStatsResponse {
@@ -79,8 +80,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Check if user has access (domain validation)
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/credit-packages/[id]/route.ts
+++ b/src/app/api/credit-packages/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { adminService } from '@/db/services';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -12,8 +13,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     }
 
     // Check if user is from allowed domain
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 
@@ -48,8 +48,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     }
 
     // Check if user is from allowed domain
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 
@@ -85,8 +84,7 @@ export async function DELETE(request: NextRequest, { params }: { params: Promise
     }
 
     // Check if user is from allowed domain
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/credit-packages/[id]/toggle/route.ts
+++ b/src/app/api/credit-packages/[id]/toggle/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { adminService } from '@/db/services';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -12,8 +13,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     }
 
     // Check if user is from allowed domain
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/credit-packages/route.ts
+++ b/src/app/api/credit-packages/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { adminService } from '@/db/services';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 export async function GET(request: NextRequest) {
   try {
@@ -11,8 +12,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Check if user is from allowed domain
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 
@@ -54,8 +54,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Check if user is from allowed domain
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/notifications/channels/route.ts
+++ b/src/app/api/notifications/channels/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 interface NotificationChannel {
   id: string;
@@ -76,8 +77,7 @@ export async function GET() {
     }
 
     // Check if user has admin access
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 
@@ -108,8 +108,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Check if user has admin access
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/notifications/rules/[id]/route.ts
+++ b/src/app/api/notifications/rules/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 interface NotificationRule {
   id: string;
@@ -65,8 +66,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     }
 
     // Check if user has admin access
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 
@@ -105,8 +105,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     }
 
     // Check if user has admin access
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 
@@ -159,8 +158,7 @@ export async function DELETE(request: NextRequest, { params }: { params: Promise
     }
 
     // Check if user has admin access
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/notifications/rules/route.ts
+++ b/src/app/api/notifications/rules/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 interface NotificationRule {
   id: string;
@@ -81,8 +82,7 @@ export async function GET() {
     }
 
     // Check if user has admin access
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 
@@ -114,8 +114,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Check if user has admin access
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/notifications/templates/route.ts
+++ b/src/app/api/notifications/templates/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 interface NotificationTemplate {
   id: string;
@@ -71,8 +72,7 @@ export async function GET() {
     }
 
     // Check if user has admin access
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 
@@ -103,8 +103,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Check if user has admin access
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/services/[id]/route.ts
+++ b/src/app/api/services/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { adminService } from '@/db/services';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 export async function GET(
   request: Request, 
@@ -14,8 +15,7 @@ export async function GET(
     }
 
     // Check if user has admin access
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 
@@ -51,8 +51,7 @@ export async function PUT(
     }
 
     // Check if user has admin access
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/services/route.ts
+++ b/src/app/api/services/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { adminService } from '@/db/services';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 export async function GET(request: Request) {
   try {
@@ -11,8 +12,7 @@ export async function GET(request: Request) {
     }
 
     // Check if user has admin access (email domain is already validated in auth.ts)
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 
@@ -57,8 +57,7 @@ export async function POST(request: Request) {
     }
 
     // Check if user has admin access
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/tickets/[id]/comments/route.ts
+++ b/src/app/api/tickets/[id]/comments/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { TicketService } from '@/lib/ticketing/service';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 export async function POST(
   request: Request,
@@ -14,8 +15,7 @@ export async function POST(
     }
 
     // Check if user has admin access
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/tickets/[id]/route.ts
+++ b/src/app/api/tickets/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { TicketService } from '@/lib/ticketing/service';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 export async function GET(
   request: Request,
@@ -14,8 +15,7 @@ export async function GET(
     }
 
     // Check if user has admin access
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 
@@ -60,8 +60,7 @@ export async function PATCH(
     }
 
     // Check if user has admin access
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/api/tickets/metrics/route.ts
+++ b/src/app/api/tickets/metrics/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { TicketService } from '@/lib/ticketing/service';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 export async function GET() {
   try {
@@ -11,8 +12,7 @@ export async function GET() {
     }
 
     // Check if user has admin access
-    const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-    const isAllowedDomain = allowedDomains.some(domain => 
+    const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
       session.user?.email?.endsWith(domain)
     );
 

--- a/src/app/auth/error/page.tsx
+++ b/src/app/auth/error/page.tsx
@@ -1,9 +1,10 @@
-"use client";
+'use client';
 
-import { useSearchParams } from "next/navigation";
-import Link from "next/link";
-import { MdError, MdHome } from "react-icons/md";
-import { Suspense } from "react";
+import { useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { MdError, MdHome } from 'react-icons/md';
+import { Suspense } from 'react';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 const errorMessages = {
   Configuration: "There is a problem with the server configuration.",
@@ -47,7 +48,7 @@ function AuthErrorContent() {
               </svg>
               <div className="text-sm">
                 <p className="font-medium">Domain Restriction</p>
-                <p>Only @mythoria.pt and @caravanconcierge.com email addresses are allowed.</p>
+                <p>Only {ALLOWED_DOMAINS.join(' and ')} email addresses are allowed.</p>
               </div>
             </div>
           )}

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,8 +1,9 @@
-"use client";
+'use client';
 
-import { signIn } from "next-auth/react";
-import { FcGoogle } from "react-icons/fc";
-import { useState } from "react";
+import { signIn } from 'next-auth/react';
+import { FcGoogle } from 'react-icons/fc';
+import { useState } from 'react';
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 export default function SignInPage() {
   const [isLoading, setIsLoading] = useState(false);
@@ -48,7 +49,7 @@ export default function SignInPage() {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
               </svg>
               <span className="text-sm">
-                Access restricted to @mythoria.pt and @caravanconcierge.com
+                Access restricted to {ALLOWED_DOMAINS.join(' and ')}
               </span>
             </div>
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,5 +1,6 @@
 import NextAuth from "next-auth";
 import GoogleProvider from "next-auth/providers/google";
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
   // Use JWT strategy instead of database for now to avoid initialization issues
@@ -33,8 +34,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       }
 
       // Check if email ends with allowed domains
-      const allowedDomains = ["@mythoria.pt", "@caravanconcierge.com"];
-      const isAllowedDomain = allowedDomains.some(domain => 
+      const isAllowedDomain = ALLOWED_DOMAINS.some(domain => 
         profile.email?.endsWith(domain)
       );
 

--- a/src/config/auth.ts
+++ b/src/config/auth.ts
@@ -1,0 +1,1 @@
+export const ALLOWED_DOMAINS = ['@mythoria.pt', '@caravanconcierge.com',];

--- a/src/lib/hooks/useAdminAuth.ts
+++ b/src/lib/hooks/useAdminAuth.ts
@@ -3,8 +3,7 @@
 import { useSession } from 'next-auth/react';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-
-const allowedDomains = ['@mythoria.pt', '@caravanconcierge.com'];
+import { ALLOWED_DOMAINS } from '@/config/auth';
 
 export const useAdminAuth = () => {
   const { data: session, status } = useSession();
@@ -22,7 +21,7 @@ export const useAdminAuth = () => {
     }
 
     if (session?.user) {
-      const isAllowedDomain = allowedDomains.some((domain) =>
+      const isAllowedDomain = ALLOWED_DOMAINS.some((domain) =>
         session.user?.email?.endsWith(domain),
       );
 


### PR DESCRIPTION
## Summary
- centralize allowed domain list in src/config/auth.ts
- use ALLOWED_DOMAINS constant in API routes, auth pages, and tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2008c53a483288c460f21525dc586