### PR TITLE
feat: centralize admin header and footer

### DIFF
--- a/src/app/ai-usage/page.tsx
+++ b/src/app/ai-usage/page.tsx
@@ -2,8 +2,6 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
-import AdminHeader from '@/components/AdminHeader';
-import AdminFooter from '@/components/AdminFooter';
 import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
 interface AIProvider {
@@ -177,13 +175,11 @@ export default function AIUsagePage() {
   if (loading || isLoading) {
     return (
       <div className="min-h-screen bg-base-200">
-        <AdminHeader />
         <main className="container mx-auto p-6">
           <div className="flex justify-center items-center h-64">
             <span className="loading loading-spinner loading-lg"></span>
           </div>
         </main>
-        <AdminFooter />
       </div>
     );
   }
@@ -194,7 +190,6 @@ export default function AIUsagePage() {
 
   return (
     <div className="min-h-screen bg-base-200">
-      <AdminHeader />
       <main className="container mx-auto p-6">
         <div className="mb-6">
           <div className="flex justify-between items-center">
@@ -485,7 +480,6 @@ export default function AIUsagePage() {
           </div>
         )}
       </main>
-      <AdminFooter />
     </div>
   );
 }

--- a/src/app/blog/[id]/page.tsx
+++ b/src/app/blog/[id]/page.tsx
@@ -1,8 +1,6 @@
 "use client";
 import React, { useEffect, useState, useCallback } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import AdminHeader from '../../../components/AdminHeader';
-import AdminFooter from '../../../components/AdminFooter';
 import Link from 'next/link';
 import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
@@ -222,7 +220,6 @@ export default function EditBlogPostPage() {
   if (error && isLoading) {
     return (
       <div className="min-h-screen flex flex-col">
-        <AdminHeader />
         <main className="flex-1 container mx-auto px-4 py-8">
           <div className="max-w-2xl mx-auto">
             <div className="alert alert-error">
@@ -238,14 +235,12 @@ export default function EditBlogPostPage() {
             </div>
           </div>
         </main>
-        <AdminFooter />
       </div>
     );
   }
 
   return (
     <div className="min-h-screen flex flex-col">
-      <AdminHeader />
       <main className="flex-1 container mx-auto px-4 py-8">
         <div className="max-w-7xl mx-auto space-y-6">
           <div className="flex items-center justify-between">
@@ -446,7 +441,6 @@ export default function EditBlogPostPage() {
           </div>
         </div>
       </main>
-      <AdminFooter />
     </div>
   );
 }

--- a/src/app/blog/new/page.tsx
+++ b/src/app/blog/new/page.tsx
@@ -1,8 +1,6 @@
 "use client";
 import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import AdminHeader from '../../../components/AdminHeader';
-import AdminFooter from '../../../components/AdminFooter';
 import Link from 'next/link';
 import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
@@ -66,7 +64,6 @@ export default function NewBlogPostPage() {
 
   return (
     <div className="min-h-screen flex flex-col">
-      <AdminHeader />
       <main className="flex-1 container mx-auto px-4 py-8">
         <div className="max-w-2xl mx-auto space-y-6">
           <div className="flex items-center gap-4">
@@ -173,7 +170,6 @@ export default function NewBlogPostPage() {
           </div>
         </div>
       </main>
-      <AdminFooter />
     </div>
   );
 }

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -3,8 +3,6 @@
 import React, { useEffect, useState, useCallback, Suspense } from 'react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
-import AdminHeader from '../../components/AdminHeader';
-import AdminFooter from '../../components/AdminFooter';
 import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
 interface BlogListTranslation { 
@@ -109,7 +107,6 @@ function BlogListContent() {
   return (
     <Suspense fallback={<div className="min-h-screen flex items-center justify-center"><div className="loading loading-spinner loading-lg"></div></div>}>
       <div className="min-h-screen flex flex-col">
-        <AdminHeader />
         <main className="flex-1 container mx-auto px-4 py-8">
           <div className="max-w-7xl mx-auto space-y-6">
           <div className="flex items-center justify-between">
@@ -298,7 +295,6 @@ function BlogListContent() {
           )}
           </div>
         </main>
-        <AdminFooter />
       </div>
     </Suspense>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 import type { Metadata } from 'next';
 import AuthProvider from '@/components/auth-provider';
+import LayoutWrapper from '@/components/layout-wrapper';
 
 export const metadata: Metadata = {
   title: 'Mythoria Admin Portal',
@@ -16,7 +17,7 @@ export default function RootLayout({
     <html lang="en" data-theme="mythoria">
       <body className="antialiased">
         <AuthProvider>
-          {children}
+          <LayoutWrapper>{children}</LayoutWrapper>
         </AuthProvider>
       </body>
     </html>

--- a/src/app/managers/page.tsx
+++ b/src/app/managers/page.tsx
@@ -2,8 +2,6 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import AdminHeader from '../../components/AdminHeader';
-import AdminFooter from '../../components/AdminFooter';
 import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
 interface Manager {
@@ -150,13 +148,11 @@ export default function ManagersPage() {
   if (loading || isLoading) {
     return (
       <div className="min-h-screen bg-base-200">
-        <AdminHeader />
         <main className="container mx-auto px-4 py-8">
           <div className="flex justify-center items-center h-64">
             <span className="loading loading-spinner loading-lg"></span>
           </div>
         </main>
-        <AdminFooter />
       </div>
     );
   }
@@ -167,7 +163,6 @@ export default function ManagersPage() {
 
   return (
     <div className="min-h-screen bg-base-200">
-      <AdminHeader />
       <main className="container mx-auto px-4 py-8">
         <div className="bg-base-100 rounded-lg shadow-lg p-6">
           <div className="flex justify-between items-center mb-6">
@@ -337,7 +332,6 @@ export default function ManagersPage() {
           </div>
         )}
       </main>
-      <AdminFooter />
     </div>
   );
 }

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -4,8 +4,6 @@ import { useSession } from 'next-auth/react';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import AdminHeader from '@/components/AdminHeader';
-import AdminFooter from '@/components/AdminFooter';
 
 interface NotificationRule {
   id: string;
@@ -134,18 +132,15 @@ export default function NotificationsPage() {
   if (status === 'loading' || isLoading) {
     return (
       <div className="min-h-screen bg-base-200">
-        <AdminHeader />
         <div className="flex justify-center items-center h-64">
           <span className="loading loading-spinner loading-lg"></span>
         </div>
-        <AdminFooter />
       </div>
     );
   }
 
   return (
     <div className="min-h-screen bg-base-200">
-      <AdminHeader />
       
       <div className="container mx-auto p-4">
         <div className="flex justify-between items-center mb-6">
@@ -413,7 +408,6 @@ export default function NotificationsPage() {
         )}
       </div>
 
-      <AdminFooter />
     </div>
   );
 }

--- a/src/app/notifications/rules/[id]/page.tsx
+++ b/src/app/notifications/rules/[id]/page.tsx
@@ -4,8 +4,6 @@ import { useSession } from 'next-auth/react';
 import { useEffect, useState, useCallback } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import Link from 'next/link';
-import AdminHeader from '@/components/AdminHeader';
-import AdminFooter from '@/components/AdminFooter';
 
 interface NotificationRule {
   id?: string;
@@ -199,18 +197,15 @@ export default function NotificationRulePage() {
   if (status === 'loading' || isLoading) {
     return (
       <div className="min-h-screen bg-base-200">
-        <AdminHeader />
         <div className="flex justify-center items-center h-64">
           <span className="loading loading-spinner loading-lg"></span>
         </div>
-        <AdminFooter />
       </div>
     );
   }
 
   return (
     <div className="min-h-screen bg-base-200">
-      <AdminHeader />
       
       <div className="container mx-auto p-4">
         <div className="flex items-center gap-4 mb-6">
@@ -480,7 +475,6 @@ export default function NotificationRulePage() {
         </div>
       </div>
 
-      <AdminFooter />
     </div>
   );
 }

--- a/src/app/notifications/templates/[id]/page.tsx
+++ b/src/app/notifications/templates/[id]/page.tsx
@@ -4,8 +4,6 @@ import { useSession } from 'next-auth/react';
 import { useEffect, useState, useCallback } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import Link from 'next/link';
-import AdminHeader from '@/components/AdminHeader';
-import AdminFooter from '@/components/AdminFooter';
 
 interface NotificationTemplate {
   id?: string;
@@ -175,18 +173,15 @@ Created on: {{ticket.createdAt}}`,
   if (status === 'loading' || isLoading) {
     return (
       <div className="min-h-screen bg-base-200">
-        <AdminHeader />
         <div className="flex justify-center items-center h-64">
           <span className="loading loading-spinner loading-lg"></span>
         </div>
-        <AdminFooter />
       </div>
     );
   }
 
   return (
     <div className="min-h-screen bg-base-200">
-      <AdminHeader />
       
       <div className="container mx-auto p-4">
         <div className="flex items-center gap-4 mb-6">
@@ -439,7 +434,6 @@ Created on: {{ticket.createdAt}}`,
         </div>
       </div>
 
-      <AdminFooter />
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import AdminHeader from '../components/AdminHeader';
-import AdminFooter from '../components/AdminFooter';
 import KPICard from '../components/KPICard';
 import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
@@ -56,7 +54,6 @@ export default function AdminPortal() {
 
   return (
     <div className="min-h-screen flex flex-col">
-      <AdminHeader />
       <main className="flex-1 container mx-auto px-4 py-8">
         <h1 className="text-2xl md:text-4xl font-bold text-center mb-6 md:mb-8">Dashboard</h1>
         <p className="text-center text-gray-600 text-sm md:text-base mb-6 md:mb-8">Project main indicators and KPIs</p>
@@ -103,7 +100,6 @@ export default function AdminPortal() {
           />
         </div>
       </main>
-      <AdminFooter />
     </div>
   );
 }

--- a/src/app/pricing/add/page.tsx
+++ b/src/app/pricing/add/page.tsx
@@ -2,8 +2,6 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import AdminHeader from '@/components/AdminHeader';
-import AdminFooter from '@/components/AdminFooter';
 import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
 export default function AddCreditPackagePage() {
@@ -70,13 +68,11 @@ export default function AddCreditPackagePage() {
   if (loading) {
     return (
       <div className="min-h-screen bg-base-200">
-        <AdminHeader />
         <main className="container mx-auto p-6">
           <div className="flex justify-center items-center h-64">
             <span className="loading loading-spinner loading-lg"></span>
           </div>
         </main>
-        <AdminFooter />
       </div>
     );
   }
@@ -87,7 +83,6 @@ export default function AddCreditPackagePage() {
 
   return (
     <div className="min-h-screen bg-base-200">
-      <AdminHeader />
       <main className="container mx-auto p-6">
         <div className="mb-6">
           <div className="flex items-center gap-2 mb-2">
@@ -226,7 +221,6 @@ export default function AddCreditPackagePage() {
           </div>
         </div>
       </main>
-      <AdminFooter />
     </div>
   );
 }

--- a/src/app/pricing/edit/[id]/page.tsx
+++ b/src/app/pricing/edit/[id]/page.tsx
@@ -2,8 +2,6 @@
 
 import { useEffect, useState, use, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
-import AdminHeader from '@/components/AdminHeader';
-import AdminFooter from '@/components/AdminFooter';
 import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
 interface CreditPackage {
@@ -133,13 +131,11 @@ export default function EditCreditPackagePage({ params }: { params: Promise<{ id
   if (loading || isLoading) {
     return (
       <div className="min-h-screen bg-base-200">
-        <AdminHeader />
         <main className="container mx-auto p-6">
           <div className="flex justify-center items-center h-64">
             <span className="loading loading-spinner loading-lg"></span>
           </div>
         </main>
-        <AdminFooter />
       </div>
     );
   }
@@ -151,20 +147,17 @@ export default function EditCreditPackagePage({ params }: { params: Promise<{ id
   if (!creditPackage) {
     return (
       <div className="min-h-screen bg-base-200">
-        <AdminHeader />
         <main className="container mx-auto p-6">
           <div className="alert alert-error">
             <span>Credit package not found</span>
           </div>
         </main>
-        <AdminFooter />
       </div>
     );
   }
 
   return (
     <div className="min-h-screen bg-base-200">
-      <AdminHeader />
       <main className="container mx-auto p-6">
         <div className="mb-6">
           <div className="flex items-center gap-2 mb-2">
@@ -346,7 +339,6 @@ export default function EditCreditPackagePage({ params }: { params: Promise<{ id
           </div>
         </div>
       </main>
-      <AdminFooter />
     </div>
   );
 }

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -2,8 +2,6 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import AdminHeader from '@/components/AdminHeader';
-import AdminFooter from '@/components/AdminFooter';
 import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
 interface CreditPackage {
@@ -70,13 +68,11 @@ export default function PricingPage() {
   if (loading || isLoading) {
     return (
       <div className="min-h-screen bg-base-200">
-        <AdminHeader />
         <main className="container mx-auto p-6">
           <div className="flex justify-center items-center h-64">
             <span className="loading loading-spinner loading-lg"></span>
           </div>
         </main>
-        <AdminFooter />
       </div>
     );
   }
@@ -87,7 +83,6 @@ export default function PricingPage() {
 
   return (
     <div className="min-h-screen bg-base-200">
-      <AdminHeader />
       <main className="container mx-auto p-6">
         <div className="mb-6">
           <h1 className="text-3xl font-bold text-base-content mb-2">Credit Package Management</h1>
@@ -163,7 +158,6 @@ export default function PricingPage() {
           </div>
         </div>
       </main>
-      <AdminFooter />
     </div>
   );
 }

--- a/src/app/revenue/page.tsx
+++ b/src/app/revenue/page.tsx
@@ -2,8 +2,6 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import AdminHeader from '@/components/AdminHeader';
-import AdminFooter from '@/components/AdminFooter';
 import { formatAdminDate } from '@/lib/date-utils';
 import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
@@ -93,13 +91,11 @@ export default function RevenuePage() {
   if (loading || isLoading) {
     return (
       <div className="min-h-screen bg-base-200">
-        <AdminHeader />
         <main className="container mx-auto p-6">
           <div className="flex justify-center items-center h-64">
             <span className="loading loading-spinner loading-lg"></span>
           </div>
         </main>
-        <AdminFooter />
       </div>
     );
   }
@@ -110,7 +106,6 @@ export default function RevenuePage() {
 
   return (
     <div className="min-h-screen bg-base-200">
-      <AdminHeader />
       <main className="container mx-auto p-6">
         <div className="mb-6">
           <div className="flex justify-between items-center">
@@ -268,7 +263,6 @@ export default function RevenuePage() {
           </div>
         </div>
       </main>
-      <AdminFooter />
     </div>
   );
 }

--- a/src/app/server-status/page.tsx
+++ b/src/app/server-status/page.tsx
@@ -2,8 +2,6 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import AdminHeader from '@/components/AdminHeader';
-import AdminFooter from '@/components/AdminFooter';
 import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
 interface ServiceStatus {
@@ -205,7 +203,6 @@ export default function ServerStatusPage() {
 
   return (
     <div className="min-h-screen flex flex-col">
-      <AdminHeader />
       <main className="flex-1 container mx-auto px-4 py-6 md:py-8">
         <div className="max-w-6xl mx-auto">
           {/* Header */}
@@ -345,7 +342,6 @@ export default function ServerStatusPage() {
           </div>
         </div>
       </main>
-      <AdminFooter />
     </div>
   );
 }

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -2,8 +2,6 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import AdminHeader from '@/components/AdminHeader';
-import AdminFooter from '@/components/AdminFooter';
 import { formatAdminDate } from '@/lib/date-utils';
 import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
@@ -138,13 +136,11 @@ export default function ServicesPage() {
   if (loading || isLoading) {
     return (
       <div className="min-h-screen bg-base-200">
-        <AdminHeader />
         <main className="container mx-auto p-6">
           <div className="flex justify-center items-center h-64">
             <span className="loading loading-spinner loading-lg"></span>
           </div>
         </main>
-        <AdminFooter />
       </div>
     );
   }
@@ -155,7 +151,6 @@ export default function ServicesPage() {
 
   return (
     <div className="min-h-screen bg-base-200">
-      <AdminHeader />
       <main className="container mx-auto p-6">
         <div className="flex justify-between items-center mb-6">
           <h1 className="text-3xl font-bold text-gray-800">Services Management</h1>
@@ -353,7 +348,6 @@ export default function ServicesPage() {
           </div>
         </div>
       </main>
-      <AdminFooter />
     </div>
   );
 }

--- a/src/app/stories/[storyId]/page.tsx
+++ b/src/app/stories/[storyId]/page.tsx
@@ -4,8 +4,6 @@ import { useEffect, useState, useCallback } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
-import AdminHeader from '../../../components/AdminHeader';
-import AdminFooter from '../../../components/AdminFooter';
 import { formatAdminDateTime } from '@/lib/date-utils';
 import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
@@ -218,7 +216,6 @@ export default function StoryDetailPage() {
   if (!story) {
     return (
       <div className="min-h-screen bg-base-200">
-        <AdminHeader />
         <main className="container mx-auto p-6">
           <div className="text-center">
             <h1 className="text-2xl font-bold">Story Not Found</h1>
@@ -227,14 +224,12 @@ export default function StoryDetailPage() {
             </Link>
           </div>
         </main>
-        <AdminFooter />
       </div>
     );
   }
 
   return (
     <div className="min-h-screen bg-base-200">
-      <AdminHeader />
       <main className="container mx-auto p-6">
         {/* Header */}
         <div className="flex justify-between items-center mb-6">
@@ -601,7 +596,6 @@ export default function StoryDetailPage() {
         </div>
       )}
 
-      <AdminFooter />
     </div>
   );
 }

--- a/src/app/stories/[storyId]/read/chapter/[chapterNumber]/page.tsx
+++ b/src/app/stories/[storyId]/read/chapter/[chapterNumber]/page.tsx
@@ -3,8 +3,6 @@
 import { useSession } from 'next-auth/react';
 import { useEffect, useState, useCallback } from 'react';
 import { useRouter, useParams } from 'next/navigation';
-import AdminHeader from '../../../../../../components/AdminHeader';
-import AdminFooter from '../../../../../../components/AdminFooter';
 import AdminStoryReader from '../../../../../../components/AdminStoryReader';
 
 interface Chapter {
@@ -100,7 +98,6 @@ export default function ReadChapterPage() {
   if (error) {
     return (
       <div className="min-h-screen bg-base-200">
-        <AdminHeader />
         <main className="container mx-auto p-6">
           <div className="text-center">
             <div className="text-6xl mb-4">📚</div>
@@ -114,7 +111,6 @@ export default function ReadChapterPage() {
             </button>
           </div>
         </main>
-        <AdminFooter />
       </div>
     );
   }
@@ -122,7 +118,6 @@ export default function ReadChapterPage() {
   if (!story || !currentChapter) {
     return (
       <div className="min-h-screen bg-base-200">
-        <AdminHeader />
         <main className="container mx-auto p-6">
           <div className="text-center">
             <div className="text-6xl mb-4">📚</div>
@@ -136,14 +131,12 @@ export default function ReadChapterPage() {
             </button>
           </div>
         </main>
-        <AdminFooter />
       </div>
     );
   }
 
   return (
     <div className="min-h-screen bg-gray-100 text-black">
-      <AdminHeader />
       
       {/* Story Reader */}
       <AdminStoryReader
@@ -153,7 +146,6 @@ export default function ReadChapterPage() {
         currentChapter={chapterNumber}
       />
 
-  <AdminFooter />
     </div>
   );
 }

--- a/src/app/stories/[storyId]/read/page.tsx
+++ b/src/app/stories/[storyId]/read/page.tsx
@@ -2,8 +2,6 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import { useRouter, useParams } from 'next/navigation';
-import AdminHeader from '../../../../components/AdminHeader';
-import AdminFooter from '../../../../components/AdminFooter';
 import AdminStoryReader from '../../../../components/AdminStoryReader';
 import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
@@ -95,7 +93,6 @@ export default function ReadStoryPage() {
   if (error) {
     return (
       <div className="min-h-screen bg-base-200">
-        <AdminHeader />
         <main className="container mx-auto p-6">
           <div className="text-center">
             <div className="text-6xl mb-4">📚</div>
@@ -109,7 +106,6 @@ export default function ReadStoryPage() {
             </button>
           </div>
         </main>
-        <AdminFooter />
       </div>
     );
   }
@@ -117,7 +113,6 @@ export default function ReadStoryPage() {
   if (!story || chapters.length === 0) {
     return (
       <div className="min-h-screen bg-base-200">
-        <AdminHeader />
         <main className="container mx-auto p-6">
           <div className="text-center">
             <h1 className="text-3xl font-bold mb-4">No Chapters Found</h1>
@@ -130,14 +125,12 @@ export default function ReadStoryPage() {
             </button>
           </div>
         </main>
-        <AdminFooter />
       </div>
     );
   }
 
   return (
     <div className="min-h-screen bg-gray-100 text-black">
-      <AdminHeader />
       
       {/* Story Reader - First page with cover and table of contents */}
       <AdminStoryReader
@@ -147,7 +140,6 @@ export default function ReadStoryPage() {
         currentChapter={0} // 0 = first page
       />
 
-  <AdminFooter />
     </div>
   );
 }

--- a/src/app/stories/page.tsx
+++ b/src/app/stories/page.tsx
@@ -3,8 +3,6 @@
 import { useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import AdminHeader from '@/components/AdminHeader';
-import AdminFooter from '@/components/AdminFooter';
 import { formatAdminDate } from '@/lib/date-utils';
 import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
@@ -132,13 +130,11 @@ export default function StoriesPage() {
   if (loading || isLoading) {
     return (
       <div className="min-h-screen bg-base-200">
-        <AdminHeader />
         <main className="container mx-auto p-6">
           <div className="flex justify-center items-center h-64">
             <span className="loading loading-spinner loading-lg"></span>
           </div>
         </main>
-        <AdminFooter />
       </div>
     );
   }
@@ -149,7 +145,6 @@ export default function StoriesPage() {
 
   return (
     <div className="min-h-screen bg-base-200">
-      <AdminHeader />
       <main className="container mx-auto p-4 md:p-6">
         <div className="mb-4 md:mb-6">
           <h1 className="text-2xl md:text-3xl font-bold text-base-content mb-1 md:mb-2">Stories Management</h1>
@@ -360,7 +355,6 @@ export default function StoriesPage() {
           </div>
         )}
       </main>
-      <AdminFooter />
     </div>
   );
 }

--- a/src/app/tickets/[id]/page.tsx
+++ b/src/app/tickets/[id]/page.tsx
@@ -3,8 +3,6 @@
 import { useEffect, useState, useCallback } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import Link from 'next/link';
-import AdminHeader from '@/components/AdminHeader';
-import AdminFooter from '@/components/AdminFooter';
 import { getDisplaySubject, getFormattedTicketNumber } from '@/lib/ticketing/utils';
 import { formatAdminDateTime } from '@/lib/date-utils';
 import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
@@ -317,13 +315,11 @@ export default function TicketDetailPage() {
   if (loading || isLoading) {
     return (
       <div className="min-h-screen bg-base-200">
-        <AdminHeader />
         <main className="container mx-auto p-4">
           <div className="flex justify-center items-center min-h-[400px]">
             <span className="loading loading-spinner loading-lg"></span>
           </div>
         </main>
-        <AdminFooter />
       </div>
     );
   }
@@ -335,7 +331,6 @@ export default function TicketDetailPage() {
   if (!ticket) {
     return (
       <div className="min-h-screen bg-base-200">
-        <AdminHeader />
         <main className="container mx-auto p-4">
           <div className="text-center py-8">
             <h1 className="text-2xl font-bold mb-4">Ticket Not Found</h1>
@@ -344,14 +339,12 @@ export default function TicketDetailPage() {
             </Link>
           </div>
         </main>
-        <AdminFooter />
       </div>
     );
   }
 
   return (
     <div className="min-h-screen bg-base-200">
-      <AdminHeader />
       
       <main className="container mx-auto p-4">
         {/* Header */}
@@ -597,7 +590,6 @@ export default function TicketDetailPage() {
         </div>
       </main>
 
-      <AdminFooter />
     </div>
   );
 }

--- a/src/app/tickets/page.tsx
+++ b/src/app/tickets/page.tsx
@@ -3,8 +3,6 @@
 import { useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import AdminHeader from '@/components/AdminHeader';
-import AdminFooter from '@/components/AdminFooter';
 import { getDisplaySubject, getFormattedTicketNumber } from '@/lib/ticketing/utils';
 import { formatAdminDate } from '@/lib/date-utils';
 import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
@@ -172,13 +170,11 @@ export default function TicketsPage() {
   if (loading || isLoading) {
     return (
       <div className="min-h-screen bg-base-200">
-        <AdminHeader />
         <main className="container mx-auto p-4">
           <div className="flex justify-center items-center min-h-[400px]">
             <span className="loading loading-spinner loading-lg"></span>
           </div>
         </main>
-        <AdminFooter />
       </div>
     );
   }
@@ -189,7 +185,6 @@ export default function TicketsPage() {
 
   return (
     <div className="min-h-screen bg-base-200">
-      <AdminHeader />
       
       <main className="container mx-auto p-4">
         <div className="mb-4 md:mb-6">
@@ -369,7 +364,6 @@ export default function TicketsPage() {
         </div>
       </main>
 
-      <AdminFooter />
     </div>
   );
 }

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -3,8 +3,6 @@
 import { useEffect, useState, useCallback } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import Link from 'next/link';
-import AdminHeader from '../../../components/AdminHeader';
-import AdminFooter from '../../../components/AdminFooter';
 import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
 interface User {
@@ -193,13 +191,11 @@ export default function UserDetailPage() {
   if (loading || isLoading) {
     return (
       <div className="min-h-screen bg-base-100">
-        <AdminHeader />
         <main className="container mx-auto px-4 py-8">
           <div className="flex justify-center items-center h-64">
             <span className="loading loading-spinner loading-lg"></span>
           </div>
         </main>
-        <AdminFooter />
       </div>
     );
   }
@@ -211,7 +207,6 @@ export default function UserDetailPage() {
   if (!user) {
     return (
       <div className="min-h-screen bg-base-100">
-        <AdminHeader />
         <main className="container mx-auto px-4 py-8">
           <div className="text-center">
             <h1 className="text-2xl font-bold mb-4">User not found</h1>
@@ -220,14 +215,12 @@ export default function UserDetailPage() {
             </Link>
           </div>
         </main>
-        <AdminFooter />
       </div>
     );
   }
 
   return (
     <div className="min-h-screen bg-base-100">
-      <AdminHeader />
       <main className="container mx-auto px-4 py-8">
         {/* Header */}
         <div className="flex justify-between items-center mb-8">
@@ -476,7 +469,6 @@ export default function UserDetailPage() {
         </div>
       )}
 
-      <AdminFooter />
     </div>
   );
 }

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -3,8 +3,6 @@
 import { useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import AdminHeader from '../../components/AdminHeader';
-import AdminFooter from '../../components/AdminFooter';
 import { formatAdminDate } from '@/lib/date-utils';
 import { useAdminAuth } from '@/lib/hooks/useAdminAuth';
 
@@ -117,7 +115,6 @@ export default function UsersPage() {
 
   return (
     <div className="min-h-screen flex flex-col">
-      <AdminHeader />
       <main className="flex-1 container mx-auto px-4 py-6 md:py-8">
         <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2 mb-6 md:mb-8">
           <div>
@@ -297,7 +294,6 @@ export default function UsersPage() {
           </div>
         )}
       </main>
-      <AdminFooter />
     </div>
   );
 }

--- a/src/app/workflows/page.tsx
+++ b/src/app/workflows/page.tsx
@@ -3,8 +3,6 @@
 import { useState, useEffect } from 'react';
 import { useSession } from 'next-auth/react';
 import { redirect } from 'next/navigation';
-import AdminHeader from '@/components/AdminHeader';
-import AdminFooter from '@/components/AdminFooter';
 import WorkflowsList from './components/WorkflowsList';
 
 export default function WorkflowsPage() {
@@ -152,7 +150,6 @@ export default function WorkflowsPage() {
 
   return (
     <div className="min-h-screen bg-base-200">
-      <AdminHeader />
       
       <div className="container mx-auto px-4 py-6 md:py-8">
         <div className="mb-6 md:mb-8">
@@ -239,7 +236,6 @@ export default function WorkflowsPage() {
         </div>
       </div>
 
-      <AdminFooter />
     </div>
   );
 }

--- a/src/components/layout-wrapper.tsx
+++ b/src/components/layout-wrapper.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import AdminHeader from '@/components/AdminHeader';
+import AdminFooter from '@/components/AdminFooter';
+
+interface LayoutWrapperProps {
+  children: React.ReactNode;
+}
+
+export default function LayoutWrapper({ children }: LayoutWrapperProps) {
+  const pathname = usePathname();
+  const hideHeaderFooter = pathname.startsWith('/auth');
+
+  return (
+    <>
+      {!hideHeaderFooter && <AdminHeader />}
+      {children}
+      {!hideHeaderFooter && <AdminFooter />}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- wrap all pages with AdminHeader and AdminFooter via a LayoutWrapper
- drop per-page header/footer imports and usage
- hide layout chrome on /auth routes to keep sign-in and error pages clean

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3e5dbbd1883289c2a77124e4b01ed