### PR TITLE
[codex] verify Admin Cloud Run timeout after deploy

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -187,6 +187,8 @@ substitutions:
 
 The deployment runtime is pinned to Node.js `24.15.0` LTS. Keep `_NODE_VERSION`, the Dockerfile default `NODE_VERSION`, `.node-version`, `.nvmrc`, and `package.json` `engines.node` aligned when the LTS version changes.
 
+The production Admin deployment must keep Cloud Run request timeout at `3600s`. MCP uses long-lived SSE connections on `/api/mcp`, and the Cloud Run default `300s` timeout causes noisy truncated-response warnings even when the client reconnects. The deploy scripts run `scripts/verify-cloud-run-timeout.ps1` after Cloud Build completes and fail the deploy if the live service timeout drifts from `3600s`.
+
 ### 3. Next.js Configuration (`next.config.ts`)
 
 ```typescript

--- a/scripts/deploy-production.ps1
+++ b/scripts/deploy-production.ps1
@@ -68,6 +68,12 @@ if ($LASTEXITCODE -eq 0) {
     Write-Host "  - Service: $SERVICE_NAME"
     Write-Host "  - Region: $REGION"
     Write-Host "  - URL: $serviceUrl"
+
+    & (Join-Path $PSScriptRoot "verify-cloud-run-timeout.ps1") -ServiceName $SERVICE_NAME -Region $REGION -ExpectedTimeoutSeconds 3600
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "[ERR] Post-deploy timeout verification failed"
+        exit 1
+    }
 } else {
     Write-Host "[ERR] Deployment failed. Check the logs above for details."
     exit 1

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -169,6 +169,12 @@ try {
         Write-Host "  - URL: $serviceUrl"
     }
 
+    & (Join-Path $PSScriptRoot "verify-cloud-run-timeout.ps1") -ServiceName $SERVICE_NAME -Region $Region -ExpectedTimeoutSeconds 3600
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "[ERR] Post-deploy timeout verification failed"
+        exit 1
+    }
+
 }
 catch {
     Write-Host "[ERR] Deployment failed with error: $($_.Exception.Message)"

--- a/scripts/verify-cloud-run-timeout.ps1
+++ b/scripts/verify-cloud-run-timeout.ps1
@@ -1,0 +1,33 @@
+# Verifies Cloud Run request timeout after deploy.
+
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$ServiceName = "mythoria-admin",
+
+    [Parameter(Mandatory = $false)]
+    [string]$Region = "europe-west9",
+
+    [Parameter(Mandatory = $false)]
+    [int]$ExpectedTimeoutSeconds = 3600
+)
+
+$ErrorActionPreference = "Stop"
+$global:PSNativeCommandUseErrorActionPreference = $false
+
+Write-Host "[INFO] Verifying Cloud Run timeout for $ServiceName in $Region..."
+
+$actualTimeout = gcloud run services describe $ServiceName --region=$Region --format="value(spec.template.spec.timeoutSeconds)" 2>$null
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($actualTimeout)) {
+    Write-Host "[ERR] Could not read Cloud Run timeout for $ServiceName"
+    exit 1
+}
+
+$actualTimeoutSeconds = [int]$actualTimeout
+if ($actualTimeoutSeconds -ne $ExpectedTimeoutSeconds) {
+    Write-Host "[ERR] Cloud Run timeout drift detected for $ServiceName"
+    Write-Host "  - Expected: $ExpectedTimeoutSeconds seconds"
+    Write-Host "  - Actual: $actualTimeoutSeconds seconds"
+    exit 1
+}
+
+Write-Host "[OK] Cloud Run timeout verified: $actualTimeoutSeconds seconds"


### PR DESCRIPTION
## Summary

- add a post-deploy Cloud Run timeout verifier for `mythoria-admin`
- call the verifier from both deploy scripts so timeout drift fails the deploy
- document why Admin must keep `3600s` for long-lived MCP SSE connections

## Impact

This does not change the Cloud Run timeout by itself; it makes deploy scripts verify that the live Admin service timeout is `3600s` after deployment. That catches the current drift where live Cloud Run is still `300s` despite repo deploy config already specifying `3600s`, reducing noisy MCP SSE truncated-response warnings.

## Rollback

Revert this PR to remove the post-deploy guard. The existing `cloudbuild.yaml` timeout configuration remains the source of truth. If the guard blocks a deploy unexpectedly, inspect `gcloud run services describe mythoria-admin --region=europe-west9 --format=value(spec.template.spec.timeoutSeconds)` before bypassing it.

## Validation

- `npx prettier --check docs/deployment.md`
- `gcloud run services describe mythoria-admin --region=europe-west9 --format=value(spec.template.spec.timeoutSeconds)` returned `300` before deploy
- PowerShell verifier not executed locally because `pwsh`/`powershell` is unavailable on this host